### PR TITLE
Update to s3fs-fuse 1.87

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,26 +6,27 @@ s3fs-fuse
     <th colspan="2">Statuses</th>
   </tr>
   <tr>
-    <td>Tests and RPM Builds<br />(CentOS6, CentOS7, Amazon Linux 2017.03)</td>
+    <td>Tests and RPM Builds<br />(CentOS7, Amazon Linux 2017.03)</td>
     <td>
       <a href="https://jenkins.juliogonzalez.es/job/s3fs-fuse-rpm-build/" target="_blank"><img src="https://jenkins.juliogonzalez.es/job/s3fs-fuse-rpm-build/badge/icon" alt="Test status" valign="middle" /></a>
     </td>
   </tr>
   <tr>
-    <td>COPR RPM Builds<br />(Fedora 27/28/29/rawhide, EPEL7)</td>
+    <td>COPR RPM Builds<br />(Fedora and EPEL7)</td>
     <td>
-      <a href="https://copr.fedorainfracloud.org/coprs/juliogonzalez/s3fs-fuse/monitor/" target="_blanK"><img src="https://copr.fedorainfracloud.org/coprs/juliogonzalez/s3fs-fuse/package/s3fs-fuse/status_image/last_build.png" alt="RPM Build status" valign="middle" /></a>
+      <a href="https://copr.fedorainfracloud.org/coprs/juliogonzalez/s3fs-fuse/monitor/" target="_blank"><img src="https://copr.fedorainfracloud.org/coprs/juliogonzalez/s3fs-fuse/package/s3fs-fuse/status_image/last_build.png" alt="RPM Build status" valign="middle" /></a>
     </td>
   </tr>
 </table>
 
-CentOS/RH/Amazon RPMs for S3FS-Fuse <https://github.com/s3fs-fuse/s3fs-fuse>
+CentOS/RH/Amazon RPMs for s3fs <https://github.com/s3fs-fuse/s3fs-fuse>
 
 Based off the [spec file](http://kad.fedorapeople.org/packages/s3fs/s3fs.spec) created by [Jorge A Gallegos](http://kad.fedorapeople.org/), referenced at <https://bugzilla.redhat.com/show_bug.cgi?id=725292>, and upgraded by [Corey Gilmore](https://github.com/cfg), refered at <https://github.com/cfg/s3fs>
 
-Includes scripts to create RPMs for fuse-2.8.5 if needed.
 
-Tested on x64 CentOS 6, CentOS 7 and Amazon Linux 2017.03
+Tested on x64 CentOS 7 and Amazon Linux 2017.03
+
+**WARNING**: CentOS6/RHEL6 are **not** supported since s3fs v1.87 as discussed at https://github.com/s3fs-fuse/s3fs-fuse/issues/1354 If you still want to use s3fs, use [v1.86-2](https://github.com/juliogonzalez/s3fs-fuse-rpm/releases/tag/1.86-2)
 
 Source for Fedora and EPEL
 --------------------------
@@ -36,32 +37,18 @@ As of today, the SPEC in this repository is exactly the same that is then pushed
 Build Requirements
 ------------------
 
-All cases:
-
 * automake
-* make
-* git
 * curl
-* rpm-build
-
-fuse 2.85 (if you need to compile it):
-
-* kernel-devel packages (or kernel source) installed that is the SAME version of your running kernel
-* gcc
-* libselinux-devel
-* libtool
-* gettext-devel
-
-s3fs:
-
-* fuse-devel (>= 2.8.4, from your distribution, or from this repository)
+* make
+* fuse-devel (>= 2.8.4)
+* git (to clone this repository, not needed if you download a tarball from the [releases](https://github.com/juliogonzalez/s3fs-fuse-rpm/releases))
 * gcc-c++
 * libcurl-devel
 * libxml2-devel
+* make
 * openssl-devel
 * pkgconfig
-* epel-rpm-macros (only for CentOS/RHEL6, from the EPEL6 repository)
-
+* rpm-build
 
 Building fresh RPMs
 -------------------
@@ -70,24 +57,6 @@ Clone the repo:
 
     git@github.com:juliogonzalez/s3fs-fuse-rpm.git
     cd s3fs-fuse-rpm
-
-
-Build fuse-2.8.5 RPMs
----------------------
-
-**WARNING**: Because fuse developers migrated from SourceForge to GitHub and deleted all content from SourceForge, the script and the SPEC to build fuse will not work before commit **daf3c1f**. If you are trying to build an old s3fs version (1.79 or older), please build fuse using commit **daf3c1f** or newer.
-
-If you do not have fuse >= 2.8.4 available (which for example is the case for CentOS 6.x), then you may compile 2.8.5 using my fork of [fuse-2.8.5-99.vitki.01.el5.src.rpm](http://rpm.vitki.net/pub/centos/6/source/fuse-2.8.5-99.vitki.01.el5.src.rpm).
-
-Otherwise, you do not need this step, but install fuse-devel and fuse-libs for your system.
-
-Rebuild:
-
-    ./fuse-rpm
-
-And install
-
-    rpm -Uvh RPMS/$HOSTTYPE/fuse-devel-2.8.5-99.vitki.03.*.$HOSTTYPE.rpm RPMS/$HOSTTYPE/fuse-libs-2.8.5-99.vitki.03.*.$HOSTTYPE.rpm
 
 
 Build the s3fs-fuse RPMs
@@ -99,4 +68,4 @@ Build the RPMs:
 
 And install:
 
-    rpm -Uvh RPMS/$HOSTTYPE/s3fs-fuse-1.84-2.*.$HOSTTYPE.rpm
+    rpm -Uvh RPMS/$HOSTTYPE/s3fs-fuse-1.87-1.*.$HOSTTYPE.rpm

--- a/SPECS/s3fs-fuse.spec
+++ b/SPECS/s3fs-fuse.spec
@@ -12,9 +12,6 @@ URL:            https://github.com/s3fs-fuse/s3fs-fuse
 Source0:        https://github.com/s3fs-fuse/s3fs-fuse/archive/v%{version}/%{name}-%{version}.tar.gz
 Source1:        passwd-s3fs
 
-# s3fs-fuse requires at least fuse 2.8.4, which is not available for
-# CentOS/RHEL6
-# See https://github.com/s3fs-fuse/s3fs-fuse/issues/42
 Requires:       fuse-libs >= 2.8.4
 # Fuse is required to be able to use mount command, /etc/fstab or mount via systemd
 Requires:       fuse >= 2.8.4

--- a/SPECS/s3fs-fuse.spec
+++ b/SPECS/s3fs-fuse.spec
@@ -2,9 +2,9 @@
 %{!?make_build: %global make_build %{__make} %{?_smp_mflags}}
 
 Name:           s3fs-fuse
-Version:        1.86
+Version:        1.87
 
-Release:        2%{?dist}
+Release:        1%{?dist}
 Summary:        FUSE-based file system backed by Amazon S3
 
 License:        GPLv2+
@@ -60,6 +60,13 @@ cp -p %{SOURCE1} passwd-s3fs
 %license COPYING
 
 %changelog
+* Mon Aug 10 2020 Julio Gonzalez Gil <packages@juliogonzalez.es> - 1.87-1
+- Update to 1.87 from https://github.com/s3fs-fuse/s3fs-fuse (#1867722)
+  Full changelog: https://github.com/s3fs-fuse/s3fs-fuse/releases/tag/v1.87
+
+* Wed Jul 29 2020 Fedora Release Engineering <releng@fedoraproject.org> - 1.86-3
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_33_Mass_Rebuild
+
 * Wed Mar 18 2020 Julio Gonzalez Gil <packages@juliogonzalez.es> - 1.86-2
 - Add mailcap dependency removed at 1.84-2. as it is in fact a runtime
   dependency to take care of mime-types on upload

--- a/ci
+++ b/ci
@@ -6,7 +6,7 @@ LANG=en_EN
 SCRIPT=$(basename ${0})
 
 # Supported distributions
-SUPPORTEDDISTROS="centos6 centos7 amazon2017.03"
+SUPPORTEDDISTROS="centos7 amazon2017.03"
 
 # Allocate tty by default
 TTY='-t'


### PR DESCRIPTION
As discussed at https://github.com/s3fs-fuse/s3fs-fuse/issues/1354, the support for CentOS6/RHEL6 is broken starting with v1.87, so this PR also removes all references to both distributions with the exception of a WARNING to instruct the users to use v1.87 until EoL of both distributions.