### PR TITLE
Fix copr builds and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ s3fs-fuse
     </td>
   </tr>
   <tr>
-    <td>COPR RPM Builds<br />(Fedora and EPEL7)</td>
+    <td>COPR RPM Builds<br />(Fedora/EPEL/CentOS Stream/RHEL/Amazon Linux)</td>
     <td>
       <a href="https://copr.fedorainfracloud.org/coprs/juliogonzalez/s3fs-fuse/monitor/" target="_blank"><img src="https://copr.fedorainfracloud.org/coprs/juliogonzalez/s3fs-fuse/package/s3fs-fuse/status_image/last_build.png" alt="RPM Build status" valign="middle" /></a>
     </td>

--- a/SOURCES/s3fs-fuse.spec
+++ b/SOURCES/s3fs-fuse.spec
@@ -1,0 +1,1 @@
+../SPECS/s3fs-fuse.spec


### PR DESCRIPTION
- Symlink for s3fs-fuse.spec at SOURCES, to make copr happy
- Correct the list of the distributions at `README.md`