### PR TITLE
We test on Rocky Linux, not AlmaLinux. Remove COPR

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,24 +8,24 @@ If you find this repository useful, you can [Buy me a beer](https://www.buymeaco
     <th colspan="2">Statuses</th>
   </tr>
   <tr>
-    <td>Tests and RPM Builds<br />(CentOS7, AlmaLinux 8, Amazon Linux 2018.03, Amazon Linux 2)</td>
+    <td>Tests and RPM Builds<br />(CentOS7, Rocky Linux 8, Amazon Linux 2018.03, Amazon Linux 2)</td>
     <td>
       <a href="https://jenkins.juliogonzalez.es/job/s3fs-fuse-rpm-build/" target="_blank"><img src="https://jenkins.juliogonzalez.es/job/s3fs-fuse-rpm-build/badge/icon" alt="Test status" valign="middle" /></a>
     </td>
   </tr>
-  <tr>
+<!-- <tr>
     <td>COPR RPM Builds<br />(Fedora/EPEL/CentOS Stream/RHEL/Amazon Linux)</td>
     <td>
       <a href="https://copr.fedorainfracloud.org/coprs/juliogonzalez/s3fs-fuse/monitor/" target="_blank"><img src="https://copr.fedorainfracloud.org/coprs/juliogonzalez/s3fs-fuse/package/s3fs-fuse/status_image/last_build.png" alt="RPM Build status" valign="middle" /></a>
     </td>
-  </tr>
+  </tr> -->
 </table>
 
 Script to generate RPMs for s3fs <https://github.com/s3fs-fuse/s3fs-fuse>
 
 Based off the [spec file](http://kad.fedorapeople.org/packages/s3fs/s3fs.spec) created by [Jorge A Gallegos](http://kad.fedorapeople.org/), referenced at <https://bugzilla.redhat.com/show_bug.cgi?id=725292>, and upgraded by [Corey Gilmore](https://github.com/cfg), refered at <https://github.com/cfg/s3fs>
 
-Tested on x64 CentOS 7, AlmaLinux 8, Amazon Linux 2018.03, Amazon Linux 2, and Amazon Linux 2023. Should also work for other versions, Rocky Linux, Oracle and similar.
+Tested on x64 CentOS 7, Rocky Linux 8, Amazon Linux 2018.03, Amazon Linux 2, and Amazon Linux 2023. Should also work for other versions and clones such as, AlmaLinux 7/8/9, Oracle and similar.
 
 **WARNING**: CentOS6/RHEL6 are **not** supported since s3fs v1.87 as discussed at https://github.com/s3fs-fuse/s3fs-fuse/issues/1354 If you still want to use s3fs, use [v1.86-2](https://github.com/juliogonzalez/s3fs-fuse-rpm/releases/tag/1.86-2)
 


### PR DESCRIPTION
COPR is removed as for now I am unable to restore the webhook to automatically build new versions, and it's basically broken since 1.91.