### PR TITLE
Update to s3fs-fuse 1.97

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ If you find this repository useful, you can [Buy me a beer](https://www.buymeaco
     <th colspan="2">Statuses</th>
   </tr>
   <tr>
-    <td>Tests and RPM Builds<br />(CentOS7, Rocky Linux 8, Amazon Linux 2018.03, Amazon Linux 2)</td>
+    <td>Tests and RPM Builds<br />(Rocky Linux 8, Amazon Linux 2023)</td>
     <td>
       <a href="https://jenkins.juliogonzalez.es/job/s3fs-fuse-rpm-build/" target="_blank"><img src="https://jenkins.juliogonzalez.es/job/s3fs-fuse-rpm-build/badge/icon" alt="Test status" valign="middle" /></a>
     </td>
@@ -41,9 +41,9 @@ Build Requirements
 * automake
 * curl
 * make
-* fuse-devel (>= 2.8.4)
+* fuse3-devel
 * git (to clone this repository, not needed if you download a tarball from the [releases](https://github.com/juliogonzalez/s3fs-fuse-rpm/releases))
-* gcc-c++
+* gcc-c++ >= 6.1.0
 * libcurl-devel
 * libxml2-devel
 * make
@@ -71,4 +71,4 @@ Build the RPMs:
 
 And install:
 
-    rpm -Uvh RPMS/$HOSTTYPE/s3fs-fuse-1.94-1.*.$HOSTTYPE.rpm
+    rpm -Uvh RPMS/$HOSTTYPE/s3fs-fuse-1.97-1.*.$HOSTTYPE.rpm

--- a/SPECS/s3fs-fuse.spec
+++ b/SPECS/s3fs-fuse.spec
@@ -2,7 +2,7 @@
 %{!?make_build: %global make_build %{__make} %{?_smp_mflags}}
 
 Name:           s3fs-fuse
-Version:        1.95
+Version:        1.97
 
 Release:        1%{?dist}
 Summary:        FUSE-based file system backed by Amazon S3
@@ -12,16 +12,16 @@ URL:            https://github.com/s3fs-fuse/s3fs-fuse
 Source0:        https://github.com/s3fs-fuse/s3fs-fuse/archive/v%{version}/%{name}-%{version}.tar.gz
 Source1:        passwd-s3fs
 
-Requires:       fuse-libs >= 2.8.4
+Requires:       fuse3-libs
 # Fuse is required to be able to use mount command, /etc/fstab or mount via systemd
-Requires:       fuse >= 2.8.4
+Requires:       fuse3
 # To identify the mime-types
 Requires:       mailcap
 BuildRequires:  automake
-BuildRequires:  gcc-c++
+BuildRequires:  gcc-c++ >= 6.1.0
 BuildRequires:  make
 BuildRequires:  pkgconfig
-BuildRequires:  pkgconfig(fuse) >= 2.8.4
+BuildRequires:  pkgconfig(fuse3)
 BuildRequires:  pkgconfig(libcurl)
 BuildRequires:  pkgconfig(libxml-2.0)
 BuildRequires:  pkgconfig(openssl)
@@ -57,6 +57,27 @@ cp -p %{SOURCE1} passwd-s3fs
 %license COPYING
 
 %changelog
+* Thu Feb  5 2026  Julio González Gil <packages@juliogonzalez.es> - 1.97-1
+- Update to 1.97 from https://github.com/s3fs-fuse/s3fs-fuse/releases/tag/v1.97 (#2416816)
+  * Bugfix: Do not honor "-o nonempty"
+
+* Thu Feb  5 2026  Julio González Gil <packages@juliogonzalez.es> - 1.96-1
+- Update to 1.96 from https://github.com/s3fs-fuse/s3fs-fuse/releases/tag/v1.96 (#2416816)
+  * Require FUSE 3 on Linux
+  * Require C++14
+  * Improve IO concurrency
+  * Rename -o endpoint to -o region for clarity
+  * Avoid HeadObject calls with improved stats cache usage
+
+* Sat Jan 17 2026 Fedora Release Engineering <releng@fedoraproject.org> - 1.95-4
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_44_Mass_Rebuild
+
+* Fri Jul 25 2025 Fedora Release Engineering <releng@fedoraproject.org> - 1.95-3
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_43_Mass_Rebuild
+
+* Sun Jan 19 2025 Fedora Release Engineering <releng@fedoraproject.org> - 1.95-2
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_42_Mass_Rebuild
+
 * Sat Oct 26 2024 Julio González Gil <packages@juliogonzalez.es> - 1.95-1
 - Update to 1.95 from https://github.com/s3fs-fuse/s3fs-fuse/releases/tag/v1.95 (#2321940)
   * IMPORTANT: This is the last release supporting CentOS7 or clones

--- a/ci
+++ b/ci
@@ -150,12 +150,12 @@ if [ "${CENGINE}" == "docker" ]; then
   container_run "${CONTAINER_NAME}" "/usr/sbin/useradd -m -d /home/${USER} -u ${UID} -g $(id -g) ${USER}" "root"
   container_run "${CONTAINER_NAME}" "/bin/chown ci:ci /home/${USER}" "root"
 fi
-print_info "Installing fuse..."
-container_run "${CONTAINER_NAME}" "/usr/bin/yum -q -y install fuse fuse-libs fuse-devel" "root" # fuse
+print_info "Installing fuse3..."
+container_run "${CONTAINER_NAME}" "/usr/bin/yum -q -y install fuse3 fuse3-libs fuse3-devel" "root" # fuse
 print_info "Building s3fs-fuse package..."
 container_run "${CONTAINER_NAME}" "./s3fs-build-rpm" "${USER}"
 print_info "Installing s3fs-fuse package..."
-container_run "${CONTAINER_NAME}" "/bin/rpm -e fuse-devel" "root"
+container_run "${CONTAINER_NAME}" "/bin/rpm -e fuse3-devel" "root"
 container_run "${CONTAINER_NAME}" "/bin/rpm -i RPMS/$HOSTTYPE/s3fs-fuse-*.*.$HOSTTYPE.rpm" "root"
 print_info "Removing s3fs-fuse package..."
 container_run "${CONTAINER_NAME}" "/bin/rpm -e s3fs-fuse" "root"


### PR DESCRIPTION
1.96 is skipped due to
https://github.com/s3fs-fuse/s3fs-fuse/issues/2760
Obsolete nonempty check from fuse2 left, while fuse3 doesn't
support nonempty

This version update also means FUSE3 and C++14 (GCC>=6.1) are
requirements, so no support for OS that do not provide them

Also incorporate the changelogs for the rebuilds from Fedora

Follows: https://github.com/s3fs-fuse/s3fs-fuse/issues/2772 and https://github.com/s3fs-fuse/s3fs-fuse/issues/2756